### PR TITLE
Compile using ia16-elf-gcc

### DIFF
--- a/boot/makefile
+++ b/boot/makefile
@@ -20,10 +20,10 @@ fat32lba.bin:    boot32lb.asm
 		$(NASM) boot32lb.asm -l$*.lst -ofat32lba.bin
 
 oemfat12.bin:   oemboot.asm
-                $(NASM) -dISFAT12 oemboot.asm -l$*.lst -ooemfat12.bin
+		$(NASM) -dISFAT12 oemboot.asm -l$*.lst -ooemfat12.bin
 
 oemfat16.bin:   oemboot.asm
-                $(NASM) -dISFAT16 oemboot.asm -l$*.lst -ooemfat16.bin
+		$(NASM) -dISFAT16 oemboot.asm -l$*.lst -ooemfat16.bin
 
 clobber:        clean
 		-$(RM) *.bin status.me

--- a/docs/build.txt
+++ b/docs/build.txt
@@ -33,6 +33,13 @@ make clean
 - to clobber (delete everything that was generated):
 make clobber
 
+You can now also cross compile with T.K. Chia's fork of ia16-elf-gcc,
+which is available at https://github.com/tkchia/gcc-ia16, using
+make all COMPILER=gcc
+or by setting COMPILER=gcc in config.mak. For now ia16-elf-gcc needs
+to be compiled from source. Only releases 20171210 and later
+are supported.
+
 Notes:
 ======
 The recommended compiler and assembler at the time of writing (2009/05/19)

--- a/drivers/makefile
+++ b/drivers/makefile
@@ -24,7 +24,7 @@
 
 OBJS   = floppy.obj rdpcclk.obj wrpcclk.obj wratclk.obj
 
-LIBOBJS= +floppy.obj +rdpcclk.obj +wrpcclk.obj +wratclk.obj
+LIBOBJS= $(LIBPLUS)floppy.obj $(LIBPLUS)rdpcclk.obj $(LIBPLUS)wrpcclk.obj $(LIBPLUS)wratclk.obj
 
 
 
@@ -45,5 +45,5 @@ clean:
 
 device.lib : $(OBJS)
 	-$(RM) device.lib
-	$(LIBUTIL) $(LIBFLAGS) device $(LIBOBJS) $(LIBTERM)
+	$(LIBUTIL) $(LIBFLAGS) device.lib $(LIBOBJS) $(LIBTERM)
 

--- a/drivers/wratclk.asm
+++ b/drivers/wratclk.asm
@@ -29,6 +29,7 @@
 ;
 
                 %include "../kernel/segs.inc"
+                %include "../hdr/stacks.inc"
 
 segment	HMA_TEXT
 
@@ -47,13 +48,14 @@ WRITEATCLOCK:
 ;               bcdMinutes = 6
 ;               bcdHours = 8
 ;               bcdDays = 10
-                mov     ch,byte [bp+8]      ;bcdHours
-                mov     cl,byte [bp+6]      ;bcdMinutes
-                mov     dh,byte [bp+4]      ;bcdSeconds
+arg bcdDays, bcdHours, bcdMinutes, bcdSeconds
+                mov     ch,byte [.bcdHours]
+                mov     cl,byte [.bcdMinutes]
+                mov     dh,byte [.bcdSeconds]
                 mov     dl,0
                 mov     ah,3
                 int     1ah
-                mov     bx,word [bp+10]     ;bcdDays
+                mov     bx,word [.bcdDays]
                 mov     dx,word [bx]
                 mov     cx,word [bx+2]
                 mov     ah,5

--- a/drivers/wrpcclk.asm
+++ b/drivers/wrpcclk.asm
@@ -28,6 +28,7 @@
 ; $Header$
 ;
         %include "../kernel/segs.inc"
+        %include "../hdr/stacks.inc"
 
 segment HMA_TEXT
 
@@ -40,8 +41,7 @@ segment HMA_TEXT
 WRITEPCCLOCK:
 ;               Ticks = 4
 		pop	ax			; return address
-		pop	dx
-		pop	cx			; Ticks
+		popargs {dx,cx}			; Ticks
 		push	ax			; restore stack
                 mov     ah,1
                 int     1ah

--- a/hdr/device.h
+++ b/hdr/device.h
@@ -483,14 +483,14 @@ extern request                  /* I/O Request packets                  */
   ASM CharReqHdr, ASM IoReqHdr, ASM MediaReqHdr;
 
 /* dsk.c */
-COUNT ASMCFUNC FAR blk_driver(rqptr rp);
+COUNT ASMCFUNC FAR blk_driver(rqptr rp, ...);
 ddt * getddt(int dev);
 
 /* error.c */
 COUNT char_error(request * rq, struct dhdr FAR * lpDevice);
 COUNT block_error(request * rq, COUNT nDrive, struct dhdr FAR * lpDevice, int mode);
 /* sysclk.c */
-WORD ASMCFUNC FAR clk_driver(rqptr rp);
+WORD ASMCFUNC FAR clk_driver(rqptr rp, ...);
 
 /* execrh.asm */
 #if defined(__WATCOMC__) && _M_IX86 >= 300

--- a/hdr/nls.h
+++ b/hdr/nls.h
@@ -403,7 +403,7 @@ struct nlsExtCntryInfo {
                                    0: 12 hours (append AM/PM)
                                    1: 24 houres
                                  */
-    VOID(FAR * upCaseFct) (VOID);       /* far call to a function upcasing the
+  intvec upCaseFct;             /* far call to a function upcasing the
                                            character in register AL */
   char dataSep[2];              /* ASCIZ of separator in data records */
 };
@@ -474,9 +474,19 @@ struct nlsInfoBlock {           /* This block contains all information
                                    maybe tweaked by NLSFUNC */
   UWORD sysCodePage;            /* system code page */
   unsigned flags;               /* implementation flags */
+#ifdef __GNUC__
+  /* need to initialize using explicit segment/offset */
+  union {
+    struct { struct nlsPackage *off; char *seg; };
+    struct nlsPackage FAR *p;
+  } actPkg, chain;
+  #define actPkg actPkg.p
+  #define chain chain.p
+#else
   struct nlsPackage FAR *actPkg;        /* current NLS package */
   struct nlsPackage FAR *chain; /* first item of info chain --
                                    hardcoded U.S.A./CP437 */
+#endif
 };
 
 extern struct nlsInfoBlock ASM nlsInfo;

--- a/hdr/nls.h
+++ b/hdr/nls.h
@@ -430,7 +430,8 @@ struct nlsPackage {             /* the contents of one chain item of the
   UWORD yeschar;                /* yes / no character DOS-65-23 */
   UWORD nochar;
   unsigned numSubfct;           /* number of supported sub-functions */
-  struct nlsPointer nlsPointers[1];     /* grows dynamically */
+  struct nlsPointer nlsPointers[5];     /* may grow dynamically */
+  struct nlsExtCntryInfo nlsExt;
 };
 
 struct nlsDBCS {                /* The internal structure is unknown to me */
@@ -479,14 +480,7 @@ struct nlsInfoBlock {           /* This block contains all information
 };
 
 extern struct nlsInfoBlock ASM nlsInfo;
-extern struct nlsPackage      FAR ASM nlsPackageHardcoded;
-        /* These are the "must have" tables within the hard coded NLS pkg */
-extern struct nlsFnamTerm     FAR ASM nlsFnameTermHardcoded;
-extern struct nlsDBCS         FAR ASM nlsDBCSHardcoded;
-extern struct nlsCharTbl      FAR ASM nlsUpcaseHardcoded;
-extern struct nlsCharTbl      FAR ASM nlsFUpcaseHardcoded;
-extern struct nlsCharTbl      FAR ASM nlsCollHardcoded;
-extern struct nlsExtCntryInfo FAR ASM nlsCntryInfoHardcoded;
+extern struct nlsPackage      DOSFAR ASM nlsPackageHardcoded;
 extern BYTE FAR hcTablesStart[], hcTablesEnd[];
 
 /***********************************************************************

--- a/hdr/portab.h
+++ b/hdr/portab.h
@@ -289,7 +289,7 @@ typedef unsigned short CLUSTER;
 #endif
 typedef unsigned short UNICODE;
 
-#if defined(STATICS) || defined(__WATCOMC__)
+#if defined(STATICS) || defined(__WATCOMC__) || defined(__GNUC__)
 #define STATIC static		 /* local calls inside module */
 #else
 #define STATIC

--- a/hdr/portab.h
+++ b/hdr/portab.h
@@ -143,6 +143,15 @@ unsigned short getSS(void);
 
 #ifdef __FAR
 #define I86
+#define __int__(intno) asm volatile("int " ## #intno)
+static inline void disable(void)
+{
+  asm volatile("cli");
+}
+static inline void enable(void)
+{
+  asm volatile("sti");
+}
 #define far __far
 #define CDECL
 #define VA_CDECL

--- a/hdr/portab.h
+++ b/hdr/portab.h
@@ -140,8 +140,34 @@ unsigned short getSS(void);
 #define MC68K
 
 #elif defined(__GNUC__)
+
+#ifdef __FAR
+#define I86
+#define far __far
+#define CDECL
+#define VA_CDECL
+#define PASCAL
+
+#define _CS getCS()
+static inline unsigned short getCS(void)
+{
+  unsigned short ret;
+  asm volatile("mov %%cs, %0" : "=r"(ret));
+  return ret;
+}
+
+#define _SS getSS()
+static inline unsigned short getSS(void)
+{
+  unsigned short ret;
+  asm volatile("mov %%ss, %0" : "=r"(ret));
+  return ret;
+}
+extern char DosDataSeg[];
+#else
 /* for warnings only ! */
 #define MC68K
+#endif
 
 #else
 #error Unknown compiler
@@ -313,7 +339,11 @@ typedef signed long LONG;
 #define FP_OFF(fp)             ((size_t)(fp))
 #endif
 
+#if defined(__GNUC__) && defined(__FAR)
+typedef VOID FAR *intvec;
+#else
 typedef VOID (FAR ASMCFUNC * intvec) (void);
+#endif
 
 #define MK_PTR(type,seg,ofs) ((type FAR*) MK_FP (seg, ofs))
 #if __TURBOC__ > 0x202

--- a/hdr/portab.h
+++ b/hdr/portab.h
@@ -198,6 +198,11 @@ typedef unsigned       size_t;
 #define ASMCFUNC CDECL
 #define ASMPASCAL PASCAL
 #define ASM ASMCFUNC
+
+/* variables that can be near or far: redefined in init-dat.h */
+#define DOSFAR
+#define DOSTEXTFAR
+
 /*                                                              */
 /* Boolean type & definitions of TRUE and FALSE boolean values  */
 /*                                                              */

--- a/hdr/process.h
+++ b/hdr/process.h
@@ -67,7 +67,7 @@ typedef struct {
      for compatiblity with CP/M apps that do a near call to psp:5
      and expect size (KB) of allocated segment in word at offset 6 */
   UBYTE ps_farcall;             /* 05  far call opcode             */
-  VOID(FAR ASMCFUNC * ps_reentry) (void);  /* 06  re-entry point          */
+  intvec ps_reentry;            /* 06  re-entry point              */
 
   intvec ps_isv22,              /* 0a terminate address            */
          ps_isv23,              /* 0e ctrl-break address           */

--- a/hdr/stacks.inc
+++ b/hdr/stacks.inc
@@ -196,3 +196,57 @@ irp_hi    equ 26
 
 	%endif
 %ENDIF
+
+; macros to define stack arguments
+; arg a, {b,4}, c
+; defines a and c as "word" arguments and b as a "dword" argument
+; for STDCALL defines .a as [bp+4], .b as [bp+6] and .c as [bp+10]
+; for PASCAL  defines .a as [bp+10], .b as [bp+6] and .c as [bp+4]
+;
+; popargs bx, {dx,ax}, cx pops these arguments of the stack (for PASCAL
+; in reverse order). Here dx,ax is a dword argument dx:ax where dx is
+; the high word. The caller is responsible for dealing with instruction
+; pointer (ip) on the stack.
+
+%ifdef gcc
+%define STDCALL
+%else
+%define PASCAL
+%endif
+
+%macro  definearg 1-2 2
+	%xdefine .%1 bp+.argloc
+	%assign .argloc .argloc+%2
+%endmacro
+
+%macro  arg 1-*
+	%assign .argloc 4
+	%rep  %0
+		%ifdef PASCAL
+			%rotate -1
+		%endif
+		definearg %1
+		%ifdef STDCALL
+			%rotate 1
+		%endif
+	%endrep
+%endmacro
+
+%macro  multipop 1-*
+	%rep %0
+		%rotate -1
+		pop %1
+	%endrep
+%endmacro
+
+%macro  popargs 1-*
+	%rep  %0
+		%ifdef PASCAL
+			%rotate -1
+		%endif
+		multipop %1
+		%ifdef STDCALL
+			%rotate 1
+		%endif
+	%endrep
+%endmacro

--- a/kernel/asmsupt.asm
+++ b/kernel/asmsupt.asm
@@ -48,6 +48,7 @@
 %ifndef WATCOM_INIT
 
 		%include "segs.inc"
+		%include "stacks.inc"
 
 %ifdef _INIT
 
@@ -134,9 +135,10 @@ pascal_setup:
                 cld
 
                 mov bl,6       ; majority (4) wants that
-                mov cx,[4+bp]  ; majority (8) wants that (near and far)
-                mov si,[6+bp]  ; majority (3) wants that (near)
-                mov di,[8+bp]  ; majority (3) wants that (near)
+arg arg1, arg2, arg3
+                mov cx,[.arg3] ; majority (8) wants that (near and far)
+                mov si,[.arg2] ; majority (3) wants that (near)
+                mov di,[.arg1] ; majority (3) wants that (near)
                 
                 jmp ax
 
@@ -192,14 +194,17 @@ FMEMCPYBACK:
 FMEMCPY:
                 call pascal_setup
 
+arg {d,4}, {s,4}, n
                 ; Get the repetition count, n preset above
-                ; mov     cx,[bp+4]
+%ifdef STDCALL
+                mov     cx,[.n]
+%endif
 
                 ; Get the far source pointer, s
-                lds     si,[bp+6]
+                lds     si,[.s]
 
                 ; Get the far destination pointer d
-                les     di,[bp+10]
+                les     di,[.d]
 		mov	bl,10
 
                 jmp short domemcpy
@@ -212,14 +217,17 @@ FMEMCPY:
 FMEMSET:
                 call pascal_setup
 
+arg {d,4}, ch, n
                 ; Get the repetition count, n - preset above
-                ; mov     cx,[bp+4]
+%ifdef STDCALL
+                mov     cx,[.n]
+%endif
 
                 ; Get the fill byte ch
-                mov     ax,[bp+6]
+                mov     ax,[.ch]
                 
                 ; Get the far source pointer, s
-                les     di,[bp+8]
+                les     di,[.d]
 		mov	bl,8
 
 domemset:                
@@ -240,11 +248,12 @@ domemset:
 MEMSET:
                 call pascal_setup
                 
+arg d, ch, n
                 ; Get the repitition count, n - preset above
                 ; mov     cx,[bp+4]
 
                 ; Get the char ch
-                mov     ax, [bp+6]
+                mov     ax, [.ch]
 
                 ; Get the far source pointer, d - preset above
                 ; mov      di,[bp+8]
@@ -282,11 +291,12 @@ pascal_return:
 FSTRCPY:
                 call pascal_setup
 
+arg {dest,4}, {src,4}
                 ; Get the source pointer, ss
-                lds   si,[bp+4]
+                lds   si,[.src]
 
                 ; and the destination pointer, d
-                les   di,[bp+8]
+                les   di,[.dest]
 
 		mov   bl,8
                 
@@ -299,11 +309,13 @@ STRCPY:
                 call pascal_setup
 
 
+%ifdef PASCAL
                 ; Get the source pointer, ss
                 mov   si,[bp+4]
 
                 ; and the destination pointer, d
                 mov   di,[bp+6]
+%endif
 		mov   bl,4
 
 dostrcpy:
@@ -334,7 +346,9 @@ FSTRLEN:
 STRLEN:
                 call pascal_setup
                 ; Get the source pointer, ss
+%ifdef PASCAL
                 mov   di,[bp+4]
+%endif
 		mov   bl,2
 
 dostrlen:           
@@ -356,8 +370,11 @@ STRCHR:
                 call pascal_setup
 
                 ; Get the source pointer, ss
-                ; mov             cx,[bp+4] - preset above
-                ; mov             si,[bp+6] - preset above
+arg src, ch
+%ifdef STDCALL	; preset above for PASCAL
+                mov             cx,[.ch]
+                mov             si,[.src]
+%endif
 		mov bl,4
 
 strchr_loop:                
@@ -388,11 +405,12 @@ strchr_found1:
 FSTRCHR:
                 call pascal_setup
 
+arg {src,4}, ch
                 ; Get ch (preset above)
                 ;mov cx, [bp+4]
                 
                 ;and the source pointer, src
-                lds si, [bp+6]
+                lds si, [.src]
 
 		;mov	bl, 6 - preset above
 
@@ -403,14 +421,17 @@ FSTRCHR:
 FMEMCHR:
                 call pascal_setup
 
+arg {src,4}, ch, n
                 ; Get the length - preset above
-                ; mov cx, [bp+4]
+%ifdef STDCALL
+                mov cx, [.n]
+%endif
 
                 ; and the search value
-                mov ax, [bp+6]
+                mov ax, [.ch]
 
                 ; and the source pointer, ss
-                les di, [bp+8]
+                les di, [.src]
 
 		mov bl, 8
 
@@ -426,11 +447,12 @@ FMEMCHR:
 FSTRCMP:
                 call pascal_setup
 
+arg {dest,4}, {src,4}
                 ; Get the source pointer, ss
-                lds             si,[bp+4]
+                lds             si,[.src]
 
                 ; and the destination pointer, d
-                les             di,[bp+8]
+                les             di,[.dest]
                 
                 mov bl,8
 
@@ -507,14 +529,17 @@ strncmp_loop:
 FMEMCMP:
                 call pascal_setup
 
+arg {dest,4}, {src,4}, n
                 ; the length - preset above
-                ; mov cx, [bp+4]
+%ifdef STDCALL
+                mov cx, [.n]
+%endif
                 
                 ; Get the source pointer, ss
-                les di,[bp+6]
+                les di,[.src]
 
                 ; and the destination pointer, d
-                lds si,[bp+10]
+                lds si,[.dest]
 
 		mov bl,10
 

--- a/kernel/chario.c
+++ b/kernel/chario.c
@@ -149,6 +149,8 @@ STATIC void fast_put_char(unsigned char chr)
 #if defined(__TURBOC__)
     _AL = chr;
     __int__(0x29);
+#elif defined(__GNUC__)
+    asm volatile("int $0x29":: "a"(chr):"bx");
 #elif defined(I86)
     asm
     {

--- a/kernel/config.c
+++ b/kernel/config.c
@@ -630,7 +630,7 @@ struct memdiskinfo {
 };
 
 /* query_memdisk() based on similar subroutine in Eric Auer's public domain getargs.asm which is based on IFMEMDSK */
-struct memdiskinfo FAR * ASMCFUNC query_memdisk(UBYTE drive);
+struct memdiskinfo FAR * ASMCFUNC query_memdisk(UBYTE drive, ...);
 
 struct memdiskopt {
   BYTE * name;

--- a/kernel/dosidle.asm
+++ b/kernel/dosidle.asm
@@ -36,15 +36,15 @@ segment HMA_TEXT
                 global  _DosIdle_int
                 global  _DosIdle_hlt
 
-                extern   _InDOS:wrt DGROUP
-                extern   _cu_psp:wrt DGROUP
-                extern   _MachineId:wrt DGROUP
-                extern   critical_sp:wrt DGROUP
-                extern   _user_r:wrt DGROUP
+                extern   _InDOS
+                extern   _cu_psp
+                extern   _MachineId
+                extern   critical_sp
+                extern   _user_r
 		; variables as the following are "part of" module inthndlr.c
 		; because of the define MAIN before include globals.h there!
-                extern   _HaltCpuWhileIdle:wrt DGROUP
-                extern   _DGROUP_:wrt HMA_TEXT
+                extern   _HaltCpuWhileIdle
+                extern   _DGROUP_
 ;
 _DosIdle_hlt:
                 push    ds

--- a/kernel/dsk.c
+++ b/kernel/dsk.c
@@ -170,7 +170,7 @@ static dsk_proc * const dispatch[NENTRY] =
 /*  F U N C T I O N S  --------------------------------------------------- */
 /* ----------------------------------------------------------------------- */
 
-COUNT ASMCFUNC FAR blk_driver(rqptr rp)
+COUNT ASMCFUNC FAR blk_driver(rqptr rp, ...)
 {
   if (rp->r_unit >= blk_dev.dh_name[0] && rp->r_command != C_INIT)
     return failure(E_UNIT);

--- a/kernel/dyninit.c
+++ b/kernel/dyninit.c
@@ -48,7 +48,6 @@ additionally:
 /*extern struct DynS FAR Dyn;*/
 
 #ifndef __TURBOC__
-#include "init-dat.h"
 extern struct DynS DOSFAR ASM Dyn;
 #else
 extern struct DynS FAR ASM Dyn;

--- a/kernel/entry.asm
+++ b/kernel/entry.asm
@@ -35,20 +35,20 @@ segment HMA_TEXT
                 extern   _int21_syscall
                 extern   _int21_service
                 extern   _int2526_handler
-                extern   _error_tos:wrt DGROUP
-                extern   _char_api_tos:wrt DGROUP
-                extern   _disk_api_tos:wrt DGROUP
-                extern   _user_r:wrt DGROUP
-                extern   _ErrorMode:wrt DGROUP
-                extern   _InDOS:wrt DGROUP
-                extern   _cu_psp:wrt DGROUP
-                extern   _MachineId:wrt DGROUP
-                extern   critical_sp:wrt DGROUP
+                extern   _error_tos
+                extern   _char_api_tos
+                extern   _disk_api_tos
+                extern   _user_r
+                extern   _ErrorMode
+                extern   _InDOS
+                extern   _cu_psp
+                extern   _MachineId
+                extern   critical_sp
 
-                extern   int21regs_seg:wrt DGROUP
-                extern   int21regs_off:wrt DGROUP
+                extern   int21regs_seg
+                extern   int21regs_off
 
-                extern   _Int21AX:wrt DGROUP
+                extern   _Int21AX
 
                 extern  _DGROUP_
 

--- a/kernel/execrh.asm
+++ b/kernel/execrh.asm
@@ -51,17 +51,18 @@ segment	HMA_TEXT
                 push    si
                 push    ds              ; sp=bp-8
 
-                lds     si,[bp+4]       ; ds:si = device header
-                les     bx,[bp+8]       ; es:bx = request header
+arg {rhp,4}, {dhp,4}
+                lds     si,[.dhp]       ; ds:si = device header
+                les     bx,[.rhp]       ; es:bx = request header
 
 
                 mov     ax, [si+6]      ; construct strategy address
-                mov     [bp+4], ax    
+                mov     [.dhp], ax
 
                 push si                 ; the bloody fucking RTSND.DOS 
                 push di                 ; driver destroys SI,DI (tom 14.2.03)
 
-                call    far[bp+4]       ; call far the strategy
+                call    far[.dhp]       ; call far the strategy
 
                 pop di 
                 pop si
@@ -69,8 +70,8 @@ segment	HMA_TEXT
                 ; Protect386Registers	; old free-EMM386 versions destroy regs in their INIT method
 
                 mov     ax,[si+8]       ; construct 'interrupt' address
-                mov     [bp+4],ax       ; construct interrupt address 
-                call    far[bp+4]       ; call far the interrupt
+                mov     [.dhp],ax       ; construct interrupt address
+                call    far[.dhp]       ; call far the interrupt
 
                 ; Restore386Registers	; less stack load and better performance...
 

--- a/kernel/fattab.c
+++ b/kernel/fattab.c
@@ -226,7 +226,7 @@ CLUSTER link_fat(struct dpb FAR * dpbp, CLUSTER Cluster1,
 
   if (ISFAT12(dpbp))
   {
-    REG UBYTE FAR *fbp0, FAR * fbp1;
+    REG UBYTE FAR *fbp0; REG UBYTE FAR * fbp1;
     struct buffer FAR * bp1;
     unsigned cluster, cluster2;
 

--- a/kernel/globals.h
+++ b/kernel/globals.h
@@ -156,18 +156,17 @@ typedef BYTE *UPMAP;
 /*                                                                      */
 /* External Assembly variables                                          */
 /*                                                                      */
-extern struct dhdr
-FAR ASM clk_dev,                    /* Clock device driver                  */
-  FAR ASM con_dev,                  /* Console device driver                */
-  FAR ASM prn_dev,                  /* Generic printer device driver        */
-  FAR ASM aux_dev,                  /* Generic aux device driver            */
-  FAR ASM blk_dev;                  /* Block device (Disk) driver           */
+extern struct dhdr FAR ASM clk_dev; /* Clock device driver                  */
+extern struct dhdr FAR ASM con_dev; /* Console device driver                */
+extern struct dhdr FAR ASM prn_dev; /* Generic printer device driver        */
+extern struct dhdr FAR ASM aux_dev; /* Generic aux device driver            */
+extern struct dhdr FAR ASM blk_dev; /* Block device (Disk) driver           */
 extern COUNT *error_tos,        /* error stack                          */
   disk_api_tos,                 /* API handler stack - disk fns         */
   char_api_tos;                 /* API handler stack - char fns         */
-extern BYTE FAR _HMATextAvailable,      /* first byte of available CODE area    */
-  FAR _HMATextStart[],          /* first byte of HMAable CODE area      */
-  FAR _HMATextEnd[];            /* and the last byte of it              */
+extern BYTE FAR _HMATextAvailable;  /* first byte of available CODE area    */
+extern BYTE FAR _HMATextStart[];    /* first byte of HMAable CODE area      */
+extern BYTE FAR _HMATextEnd[];      /* and the last byte of it              */
 extern
 BYTE DosLoadedInHMA;            /* if InitHMA has moved DOS up          */
 
@@ -236,9 +235,8 @@ extern UWORD ASM first_mcb,         /* Start of user memory                 */
   ASM uppermem_root;                /* Start of umb chain (usually 9fff)    */
 extern char * ASM inputptr;         /* pointer to unread CON input          */ 
 extern sfttbl FAR * ASM sfthead;    /* System File Table head               */
-extern struct dhdr
-FAR * ASM clock,                    /* CLOCK$ device                        */
-  FAR * ASM syscon;                 /* console device                       */
+extern struct dhdr FAR * ASM clock; /* CLOCK$ device                        */
+extern struct dhdr FAR * ASM syscon;/* console device                       */
 extern WORD ASM maxsecsize;         /* largest sector size in use (can use) */
 extern struct buffer
 FAR *ASM firstbuf;                  /* head of buffers linked list          */

--- a/kernel/globals.h
+++ b/kernel/globals.h
@@ -160,7 +160,14 @@ extern struct dhdr FAR ASM clk_dev; /* Clock device driver                  */
 extern struct dhdr FAR ASM con_dev; /* Console device driver                */
 extern struct dhdr FAR ASM prn_dev; /* Generic printer device driver        */
 extern struct dhdr FAR ASM aux_dev; /* Generic aux device driver            */
+#ifndef __GNUC__
 extern struct dhdr FAR ASM blk_dev; /* Block device (Disk) driver           */
+#else
+extern struct dhdr ASM blk_dev;
+#define DosTextSeg 0x70
+#define DOSTEXT(x) (*(typeof(x) FAR *)MK_FP(DosTextSeg, (size_t)&(x)))
+#define blk_dev DOSTEXT(blk_dev)
+#endif
 extern COUNT *error_tos,        /* error stack                          */
   disk_api_tos,                 /* API handler stack - disk fns         */
   char_api_tos;                 /* API handler stack - char fns         */

--- a/kernel/globals.h
+++ b/kernel/globals.h
@@ -363,7 +363,7 @@ VOID ASMCFUNC FAR cpm_entry(VOID)
 /*INRPT FAR handle_break(VOID) */ ;
 COUNT ASMCFUNC
     CriticalError(COUNT nFlag, COUNT nDrive, COUNT nError,
-                           struct dhdr FAR * lpDevice);
+                           struct dhdr FAR * lpDevice, ...);
 
 VOID ASMCFUNC FAR CharMapSrvc(VOID);
 #if 0

--- a/kernel/init-dat.h
+++ b/kernel/init-dat.h
@@ -1,3 +1,6 @@
+#undef DOSFAR
+#undef DOSTEXTFAR
+
 /* Included by initialisation functions */
 
 #if _MSC_VER != 0

--- a/kernel/init-dat.h
+++ b/kernel/init-dat.h
@@ -23,7 +23,7 @@ extern __segment DosTextSeg;
 #define DOSFAR FAR
 #define DOSTEXTFAR FAR
 
-#elif !defined(I86)
+#elif !defined(I86) || defined(__GNUC__)
 
 #define DOSFAR
 #define DOSTEXTFAR

--- a/kernel/init-dat.h
+++ b/kernel/init-dat.h
@@ -1,5 +1,7 @@
 #undef DOSFAR
 #undef DOSTEXTFAR
+#define DOSDATA(x) (x)
+#define DOSTEXT(x) (x)
 
 /* Included by initialisation functions */
 
@@ -23,7 +25,18 @@ extern __segment DosTextSeg;
 #define DOSFAR FAR
 #define DOSTEXTFAR FAR
 
-#elif !defined(I86) || defined(__GNUC__)
+#elif defined(__GNUC__)
+
+#define DosTextSeg 0x70
+/* XXX not supported yet */
+#define DOSFAR
+#define DOSTEXTFAR
+#undef DOSDATA
+#undef DOSTEXT
+#define DOSDATA(x) (*(typeof(x) FAR *)MK_FP(DosDataSeg, (size_t)&(x)))
+#define DOSTEXT(x) (*(typeof(x) FAR *)MK_FP(DosTextSeg, (size_t)&(x)))
+
+#elif !defined(I86)
 
 #define DOSFAR
 #define DOSTEXTFAR

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -353,8 +353,13 @@ extern struct RelocationTable
 
 extern void FAR *DOSFAR ASM XMSDriverAddress;
 #define XMSDriverAddress DOSDATA(XMSDriverAddress)
+#ifdef __GNUC__
+extern VOID _EnableA20(VOID);
+extern VOID _DisableA20(VOID);
+#else
 extern VOID ASMPASCAL FAR _EnableA20(VOID);
 extern VOID ASMPASCAL FAR _DisableA20(VOID);
+#endif
 
 extern void FAR * ASMPASCAL DetectXMSDriver(VOID);
 extern int ASMPASCAL init_call_XMScall(void FAR * driverAddress, UWORD ax,

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -220,6 +220,9 @@ VOID ASMCFUNC FAR int2a_handler(void);
 VOID ASMCFUNC FAR int2f_handler(void);
 VOID ASMCFUNC FAR cpm_entry(void);
 
+#define cpm_entry DOSDATA(cpm_entry)
+#define int29_handler DOSTEXT(int29_handler)
+
 /* kernel.asm */
 VOID ASMCFUNC FAR init_call_p_0(struct config FAR *Config); /* P_0, actually */
 
@@ -235,6 +238,7 @@ int VA_CDECL init_sprintf(char * buff, CONST char * fmt, ...);
 
 /* procsupt.asm */
 VOID ASMCFUNC FAR got_cbreak(void);
+#define got_cbreak DOSTEXT(got_cbreak)
 
 /* initclk.c */
 extern void Init_clk_driver(void);
@@ -244,6 +248,7 @@ extern UWORD HMAFree;            /* first byte in HMA not yet used      */
 extern unsigned CurrentKernelSegment;
 #ifdef __GNUC__
 extern struct _KernelConfig ASM LowKernelConfig;
+#define LowKernelConfig *(typeof(LowKernelConfig) FAR *)MK_FP(DOS_PSP, &LowKernelConfig)
 #else
 extern struct _KernelConfig FAR ASM LowKernelConfig;
 #endif
@@ -258,13 +263,16 @@ extern char master_env[128];
 extern struct lol FAR *LoL;
 
 extern struct dhdr DOSTEXTFAR ASM blk_dev; /* Block device (Disk) driver           */
+#define blk_dev DOSTEXT(blk_dev)
 
 extern struct buffer FAR *DOSFAR firstAvailableBuf; /* first 'available' buffer   */
+#define firstAvailableBuf DOSDATA(firstAvailableBuf)
 #ifdef __GNUC__
 extern struct lol ASM DATASTART;
 #else
 extern struct lol ASM FAR DATASTART;
 #endif
+#define DATASTART DOSDATA(DATASTART)
 
 extern BYTE DOSFAR ASM _HMATextAvailable;    /* first byte of available CODE area    */
 #ifdef __GNUC__
@@ -275,13 +283,18 @@ extern BYTE FAR ASM _HMATextStart[];          /* first byte of HMAable CODE area
 extern BYTE FAR ASM _HMATextEnd[];
 #endif
 extern BYTE DOSFAR ASM break_ena;  /* break enabled flag                   */
+#define break_ena DOSDATA(break_ena)
 extern BYTE DOSFAR ASM _InitTextStart[],     /* first available byte of ram          */
   DOSFAR ASM _InitTextEnd[],
   DOSFAR ASM ReturnAnyDosVersionExpected,
   DOSFAR ASM HaltCpuWhileIdle;
+#define ReturnAnyDosVersionExpected DOSDATA(ReturnAnyDosVersionExpected)
+#define HaltCpuWhileIdle DOSDATA(HaltCpuWhileIdle)
 
 extern BYTE DOSFAR ASM internal_data[];
+#define internal_data DOSDATA(internal_data)
 extern unsigned char DOSTEXTFAR ASM kbdType;
+#define kbdType DOSTEXT(kbdType)
 
 extern struct {
   char  ThisIsAConstantOne;
@@ -290,23 +303,29 @@ extern struct {
   struct CountrySpecificInfo C;
   
 } DOSFAR ASM nlsCountryInfoHardcoded;
+#define nlsCountryInfoHardcoded DOSDATA(nlsCountryInfoHardcoded)
+#define nlsPackageHardcoded DOSDATA(nlsPackageHardcoded)
 
 /*
     data shared between DSK.C and INITDISK.C
 */
 
 extern UWORD DOSFAR LBA_WRITE_VERIFY;
+#define LBA_WRITE_VERIFY DOSDATA(LBA_WRITE_VERIFY)
 
 /* original interrupt vectors, at 70:xxxx */
 extern struct lowvec {
   unsigned char intno;
   intvec isv;
 } DOSTEXTFAR ASM intvec_table[5];
+#define intvec_table DOSTEXT(intvec_table)
 
 /* floppy parameter table, at 70:xxxx */
 extern unsigned char DOSTEXTFAR ASM int1e_table[0xe];
+#define int1e_table DOSTEXT(int1e_table)
 
 extern char DOSFAR DiskTransferBuffer[/*MAX_SEC_SIZE*/]; /* in dsk.c */
+#define DiskTransferBuffer DOSDATA(DiskTransferBuffer)
 
 struct RelocationTable {
   UBYTE jmpFar;
@@ -327,8 +346,11 @@ struct RelocatedEntry {
 extern struct RelocationTable
    DOSFAR ASM _HMARelocationTableStart[],
    DOSFAR ASM _HMARelocationTableEnd[];
+#define _HMARelocationTableStart DOSDATA(_HMARelocationTableStart)
+#define _HMARelocationTableEnd DOSDATA(_HMARelocationTableEnd)
 
 extern void FAR *DOSFAR ASM XMSDriverAddress;
+#define XMSDriverAddress DOSDATA(XMSDriverAddress)
 extern VOID ASMPASCAL FAR _EnableA20(VOID);
 extern VOID ASMPASCAL FAR _DisableA20(VOID);
 

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -198,11 +198,9 @@ void ASMPASCAL set_DTA(void far *dta);
 
 /* irqstack.asm */
 VOID ASMCFUNC init_stacks(VOID FAR * stack_base, COUNT nStacks,
-                          WORD stackSize);
+                          WORD stackSize, ...);
 
 /* inthndlr.c */
-VOID ASMCFUNC FAR int21_entry(iregs UserRegs);
-VOID ASMCFUNC int21_service(iregs far * r);
 VOID ASMCFUNC FAR int0_handler(void);
 VOID ASMCFUNC FAR int6_handler(void);
 VOID ASMCFUNC FAR int19_handler(void);
@@ -224,7 +222,11 @@ VOID ASMCFUNC FAR cpm_entry(void);
 #define int29_handler DOSTEXT(int29_handler)
 
 /* kernel.asm */
+#ifdef __GNUC__
+VOID ASMCFUNC init_call_p_0(struct config FAR *Config, ...) asm("init_call_p_0");
+#else
 VOID ASMCFUNC FAR init_call_p_0(struct config FAR *Config); /* P_0, actually */
+#endif
 
 /* main.c */
 VOID ASMCFUNC FreeDOSmain(void);

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -266,8 +266,8 @@ extern BYTE DOSFAR ASM _InitTextStart[],     /* first available byte of ram     
   DOSFAR ASM ReturnAnyDosVersionExpected,
   DOSFAR ASM HaltCpuWhileIdle;
 
-extern BYTE FAR ASM internal_data[];
-extern unsigned char FAR ASM kbdType;
+extern BYTE DOSFAR ASM internal_data[];
+extern unsigned char DOSTEXTFAR ASM kbdType;
 
 extern struct {
   char  ThisIsAConstantOne;

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -16,12 +16,12 @@
 #include "tail.h"
 #include "process.h"
 #include "pcb.h"
-#include "nls.h"
 #include "buffer.h"
 #include "dcb.h"
 #include "lol.h"
 
 #include "init-dat.h"
+#include "nls.h"
 
 #include "kconfig.h"
 
@@ -275,7 +275,7 @@ extern struct {
   
   struct CountrySpecificInfo C;
   
-} FAR ASM nlsCountryInfoHardcoded;
+} DOSFAR ASM nlsCountryInfoHardcoded;
 
 /*
     data shared between DSK.C and INITDISK.C

--- a/kernel/init-mod.h
+++ b/kernel/init-mod.h
@@ -242,7 +242,11 @@ extern void Init_clk_driver(void);
 extern UWORD HMAFree;            /* first byte in HMA not yet used      */
 
 extern unsigned CurrentKernelSegment;
+#ifdef __GNUC__
+extern struct _KernelConfig ASM LowKernelConfig;
+#else
 extern struct _KernelConfig FAR ASM LowKernelConfig;
+#endif
 extern WORD days[2][13];
 extern BYTE FAR *lpTop;
 extern BYTE ASM _ib_start[], ASM _ib_end[], ASM _init_end[];
@@ -256,11 +260,21 @@ extern struct lol FAR *LoL;
 extern struct dhdr DOSTEXTFAR ASM blk_dev; /* Block device (Disk) driver           */
 
 extern struct buffer FAR *DOSFAR firstAvailableBuf; /* first 'available' buffer   */
+#ifdef __GNUC__
+extern struct lol ASM DATASTART;
+#else
 extern struct lol ASM FAR DATASTART;
+#endif
 
-extern BYTE DOSFAR ASM _HMATextAvailable,    /* first byte of available CODE area    */
-  FAR ASM _HMATextStart[],          /* first byte of HMAable CODE area      */
-  FAR ASM _HMATextEnd[], DOSFAR ASM break_ena;  /* break enabled flag                   */
+extern BYTE DOSFAR ASM _HMATextAvailable;    /* first byte of available CODE area    */
+#ifdef __GNUC__
+extern BYTE ASM _HMATextStart[];          /* first byte of HMAable CODE area      */
+extern BYTE ASM _HMATextEnd[];
+#else
+extern BYTE FAR ASM _HMATextStart[];          /* first byte of HMAable CODE area      */
+extern BYTE FAR ASM _HMATextEnd[];
+#endif
+extern BYTE DOSFAR ASM break_ena;  /* break enabled flag                   */
 extern BYTE DOSFAR ASM _InitTextStart[],     /* first available byte of ram          */
   DOSFAR ASM _InitTextEnd[],
   DOSFAR ASM ReturnAnyDosVersionExpected,

--- a/kernel/inithma.c
+++ b/kernel/inithma.c
@@ -352,7 +352,8 @@ void MoveKernel(unsigned NewKernelSegment)
        style table
      */
 
-    struct RelocationTable FAR *rp, rtemp;
+    struct RelocationTable FAR *rp;
+    struct RelocationTable rtemp;
 
     /* verify, that all entries are valid */
 

--- a/kernel/inithma.c
+++ b/kernel/inithma.c
@@ -78,7 +78,7 @@ UWORD HMAFree BSS_INIT(0);            /* first byte in HMA not yet used      */
 STATIC void InstallVDISK(void);
 
 #ifdef DEBUG
-#ifdef __TURBOC__
+#if defined(__TURBOC__) || defined(__GNUC__)
 #define int3() __int__(3);
 #else
 void int3()

--- a/kernel/inithma.c
+++ b/kernel/inithma.c
@@ -312,7 +312,14 @@ void MoveKernel(unsigned NewKernelSegment)
   unsigned jmpseg = CurrentKernelSegment;
  
   if (CurrentKernelSegment == 0)
+#ifdef __GNUC__
+    {
+      extern char TGROUP[] asm("TGROUP");
+      CurrentKernelSegment = (unsigned)TGROUP;
+    }
+#else
     CurrentKernelSegment = FP_SEG(_HMATextEnd);
+#endif
 
   if (CurrentKernelSegment == 0xffff)
     return;

--- a/kernel/int2f.asm
+++ b/kernel/int2f.asm
@@ -32,8 +32,8 @@
         %include "stacks.inc"
 
 segment	HMA_TEXT
-            extern _cu_psp:wrt DGROUP
-            extern _HaltCpuWhileIdle:wrt DGROUP
+            extern _cu_psp
+            extern _HaltCpuWhileIdle
             extern _syscall_MUX14
 
             extern _DGROUP_
@@ -123,7 +123,7 @@ Int2f?iret:
 
 ; DRIVER.SYS calls - now only 0803.
 DriverSysCal:
-                extern  _Dyn:wrt DGROUP
+                extern  _Dyn
                 cmp     al, 3
                 jne     Int2f?iret
                 mov     ds, [cs:_DGROUP_]
@@ -431,7 +431,7 @@ int2f_restore_ds:
 ; extern UWORD ASMPASCAL call_nls(UWORD bp, UWORD FAR *buf,
 ;	UWORD subfct, UWORD cp, UWORD cntry, UWORD bufsize);
 
-		extern _nlsInfo:wrt DGROUP
+		extern _nlsInfo
 		global CALL_NLS
 CALL_NLS:
 		pop	es		; ret addr

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -63,7 +63,7 @@ struct HugeSectorBlock {
 /* variables needed for the rest of the handler.                        */
 /* this here works on the users stack !! and only very few functions 
    are allowed                                                          */
-VOID ASMCFUNC int21_syscall(iregs FAR * irp)
+VOID ASMCFUNC int21_syscall(iregs FAR * irp, ...)
 {
   Int21AX = irp->AX;
 
@@ -376,7 +376,7 @@ int int21_fat32(lregs *r)
 }
 #endif
 
-VOID ASMCFUNC int21_service(iregs FAR * r)
+VOID ASMCFUNC int21_service(iregs FAR * r, ...)
 {
   COUNT rc;
   long lrc;
@@ -1625,7 +1625,7 @@ struct int25regs {
 /* 
     this function is called from an assembler wrapper function 
 */
-VOID ASMCFUNC int2526_handler(WORD mode, struct int25regs FAR * r)
+VOID ASMCFUNC int2526_handler(WORD mode, struct int25regs FAR * r, ...)
 {
   ULONG blkno;
   UWORD nblks;
@@ -1734,7 +1734,7 @@ struct int2f12regs {
 /* WARNING: modifications in `r' are used outside of int2F_12_handler()
  * On input r.AX==0x12xx, 0x4A01 or 0x4A02
  */
-VOID ASMCFUNC int2F_12_handler(struct int2f12regs r)
+VOID ASMCFUNC int2F_12_handler(struct int2f12regs r, ...)
 {
   COUNT rc;
   long lrc;

--- a/kernel/io.asm
+++ b/kernel/io.asm
@@ -31,18 +31,18 @@
                 %include "segs.inc"
                 %include "stacks.inc"
 
-                extern   ConTable:wrt LGROUP
-                extern   LptTable:wrt LGROUP
-                extern   ComTable:wrt LGROUP
-                extern   uPrtNo:wrt LGROUP
-                extern   CommonNdRdExit:wrt LGROUP
-;!!                extern   _NumFloppies:wrt DGROUP
-                extern   blk_stk_top:wrt DGROUP
-                extern   clk_stk_top:wrt DGROUP
+                extern   ConTable
+                extern   LptTable
+                extern   ComTable
+                extern   uPrtNo
+                extern   CommonNdRdExit
+;!!                extern   _NumFloppies
+                extern   blk_stk_top
+                extern   clk_stk_top
                 extern   _reloc_call_blk_driver
                 extern   _reloc_call_clk_driver
 
-                extern   _TEXT_DGROUP:wrt LGROUP                
+                extern   _TEXT_DGROUP
 
 ;---------------------------------------------------
 ;
@@ -501,12 +501,12 @@ GetUnitNum:
 blk_driver_params:
                    dw  blk_stk_top
                    dw  _reloc_call_blk_driver
-                   dw  seg _reloc_call_blk_driver
+                   dw  DGROUP
 
 clk_driver_params:
                    dw  clk_stk_top
                    dw  _reloc_call_clk_driver
-                   dw  seg _reloc_call_clk_driver
+                   dw  DGROUP
 
                 ; clock device interrupt
 clk_entry:

--- a/kernel/io.inc
+++ b/kernel/io.inc
@@ -49,12 +49,12 @@
 %define E_FAILURE       12      ; General Failure
 
 
-	extern	_IOExit:wrt LGROUP
-	extern	_IOSuccess:wrt LGROUP
-	extern	_IOErrorExit:wrt LGROUP
-	extern	_IOErrCnt:wrt LGROUP
-	extern	_IODone:wrt LGROUP
-	extern	_IOCommandError:wrt LGROUP
-	extern	GetUnitNum:wrt LGROUP
-        extern  _ReqPktPtr:wrt LGROUP
+	extern	_IOExit
+	extern	_IOSuccess
+	extern	_IOErrorExit
+	extern	_IOErrCnt
+	extern	_IODone
+	extern	_IOCommandError
+	extern	GetUnitNum
+        extern  _ReqPktPtr
 

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -889,23 +889,26 @@ __U4D:
 %endif
 
 %ifdef gcc
-global ___udivsi3
-___udivsi3:     call ldivmodu
+%macro ULONG_HELPERS 1
+global %1udivsi3
+%1udivsi3:      call %1ldivmodu
                 ret 8
 
-global ___umodsi3
-___umodsi3:     call ldivmodu
+global %1umodsi3
+%1umodsi3:      call %1ldivmodu
                 mov dx, cx
                 mov ax, bx
                 ret 8
 
-ldivmodu:       LDIVMODU
+%1ldivmodu:     LDIVMODU
 
-global ___ashlsi3
-___ashlsi3:     LSHLU
+global %1ashlsi3
+%1ashlsi3:      LSHLU
 
-global ___lshrsi3
-___lshrsi3:     LSHRU
+global %1lshrsi3
+%1lshrsi3:      LSHRU
+%endmacro
+                ULONG_HELPERS ___
 %endif
 
                 times 0xd0 - ($-begin_hma) db 0
@@ -1146,3 +1149,7 @@ _TEXT_DGROUP dw DGROUP
 segment INIT_TEXT
                 global _INIT_DGROUP
 _INIT_DGROUP dw DGROUP
+
+%ifdef gcc
+                ULONG_HELPERS _init_
+%endif

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -29,6 +29,7 @@
 ;
 
                 %include "segs.inc"
+                %include "stacks.inc"
                 %include "ludivmul.inc"
 
 

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -887,6 +887,26 @@ __U4D:
                 LDIVMODU
 %endif
 
+%ifdef gcc
+global ___udivsi3
+___udivsi3:     call ldivmodu
+                ret 8
+
+global ___umodsi3
+___umodsi3:     call ldivmodu
+                mov dx, cx
+                mov ax, bx
+                ret 8
+
+ldivmodu:       LDIVMODU
+
+global ___ashlsi3
+___ashlsi3:     LSHLU
+
+global ___lshrsi3
+___lshrsi3:     LSHRU
+%endif
+
                 times 0xd0 - ($-begin_hma) db 0
                 ; reserve space for far jump to cp/m routine
                 times 5 db 0

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -1,0 +1,186 @@
+/* Linker script for DOS executables with separate data and text segments.
+   Partly derived from dos-exe-small.ld in newlib-ia16 and elks-separate.ld. */
+
+OUTPUT_FORMAT(binary)
+
+DOS_PSP = 0x60;
+MEMOFS = DOS_PSP * 16 - SIZEOF(.hdr);
+
+/* these GROUPs play the same role as GROUPS (segments) in OMF */
+PGROUP = (MEMOFS + LOADADDR(.ptext)) / 16;
+LGROUP = (MEMOFS + LOADADDR(.ltext)) / 16;
+DGROUP = (MEMOFS + LOADADDR(.data)) / 16;
+_DosDataSeg = DGROUP;
+TGROUP = (MEMOFS + LOADADDR(.text)) / 16;
+IGROUP = (MEMOFS + LOADADDR(.itext)) / 16;
+I_GROUP = (MEMOFS + LOADADDR(.idata)) / 16;
+
+INITSIZE = SIZEOF(.itext) + SIZEOF(.idata) + SIZEOF(.ibss);
+
+SECTIONS
+  {
+    /* Fabricate a .exe header here.  Although libbfd does have an
+       "i386msdos" back-end which produces an "MZ" exe header, it cannot do
+       certain things (yet). */
+    .hdr : {
+		/* Signature.  */
+		SHORT (0x5a4d)
+		/* Bytes in last 512-byte page.  */
+		SHORT (LOADADDR (.ibss) % 512)
+		/* Total number of 512-byte pages.  */
+		SHORT (ALIGN(LOADADDR (.ibss), 512) / 512)
+		/* Relocation entries.  */
+		SHORT (0)
+		/* Header size in paragraphs.  */
+		SHORT (SIZEOF(.hdr) / 16)
+		/* Minimum extra paragraphs.  */
+		SHORT (ALIGN(SIZEOF (.ibss) + SIZEOF(.istack), 16) / 16)
+		/* Maximum extra paragraphs.  */
+		SHORT (0xffff)
+		/* Initial %ss.  */
+		SHORT (LOADADDR (.istack) / 16 )
+		/* Initial %sp. */
+		SHORT (LOADADDR (.istack) % 16 + SIZEOF(.istack))
+		/* Padding for Checksum (unused) and initial cs:ip (0:0) */
+		. = 0x18;
+		/* Relocation table offset.  */
+		SHORT (. + 4)
+		/* Overlay number + padding */
+                . = ALIGN (32);
+    }
+
+    /* Target PSP section.  */
+    .ptext 0 : AT (SIZEOF(.hdr)) {
+		*(PSP)
+    }
+
+    /* Target low data+text sections.  */
+    .ltext 0 : AT (LOADADDR(.ptext) + SIZEOF(.ptext)) {
+		*(_IRQTEXT)
+		*(_LOWTEXT)
+		*(_IO_TEXT)
+		*(_IO_FIXED_DATA)
+    }
+
+    /* Target data sections.  */
+    .data 0 : AT (ALIGN(LOADADDR(.ltext) + SIZEOF(.ltext), 16)) {
+		*(_FIXED_DATA)
+		*(_BSS)
+		*(EXCLUDE_FILE (config.obj iasmsupt.obj *init*.obj iprf.obj main.obj) .bss)
+		*(_DATA)
+		*(EXCLUDE_FILE (config.obj iasmsupt.obj *init*.obj iprf.obj main.obj) .data)
+		*(_DATAEND)
+		*(CONST)
+		*(CONST2)
+		*(EXCLUDE_FILE (config.obj iasmsupt.obj *init*.obj iprf.obj main.obj) .rodata)
+		*(EXCLUDE_FILE (config.obj iasmsupt.obj *init*.obj iprf.obj main.obj) .rodata.*)
+		*(DYN_DATA)
+		ASSERT(. <= 0xfff8,
+		    "Error: too large for a small-model .exe file.");
+	}
+
+    /* Target text sections.  */
+    .text 0 : AT (ALIGN(LOADADDR(.data) + SIZEOF(.data), 16)) {
+		*(HMA_TEXT_START)
+		*(HMA_TEXT)
+		_res_DosExec = RES_DOSEXEC;
+		_res_read = RES_READ;
+		_strlen = STRLEN;
+		_fstrlen = FSTRLEN;
+		_strlen = STRLEN;
+		_fstrcmp = FSTRCMP;
+		_strchr = STRCHR;
+		_fstrchr = FSTRCHR;
+		_fmemchr = FMEMCHR;
+		_strcpy = STRCPY;
+		_fmemcpy = FMEMCPY;
+		_fstrcpy = FSTRCPY;
+		_memcpy = MEMCPY;
+		_fmemset = FMEMSET;
+		_memset = MEMSET;
+		_memcmp = MEMCMP;
+		_fmemcmp = FMEMCMP;
+		_network_redirector_mx = NETWORK_REDIRECTOR_MX;
+		_execrh = EXECRH;
+		_share_check = SHARE_CHECK;
+		_share_open_check = SHARE_OPEN_CHECK;
+		_share_close_file = SHARE_CLOSE_FILE;
+		_share_access_check = SHARE_ACCESS_CHECK;
+		_share_lock_unlock = SHARE_LOCK_UNLOCK;
+		_call_nls = CALL_NLS;
+		_fl_reset = FL_RESET;
+		_fl_diskchanged = FL_DISKCHANGED;
+		_fl_format = FL_FORMAT;
+		_fl_read = FL_READ;
+		_fl_write = FL_WRITE;
+		_fl_verify = FL_VERIFY;
+		_fl_setdisktype = FL_SETDISKTYPE;
+		_fl_setmediatype = FL_SETMEDIATYPE;
+		_fl_readkey = FL_READKEY;
+		_fl_lba_ReadWrite = FL_LBA_READWRITE;
+		_floppy_change = FLOPPY_CHANGE;
+		_ReadPCClock = READPCCLOCK;
+		_WritePCClock = WRITEPCCLOCK;
+		_WriteATClock = WRITEATCLOCK;
+		*(EXCLUDE_FILE (config.obj iasmsupt.obj *init*.obj iprf.obj main.obj) .text)
+		*(HMA_TEXT_END)
+		ASSERT(. <= 0x10000,
+		    "Error: too large for a small-model .exe file.");
+	}
+
+    /* Target init text sections. */
+    .itext 0 : AT (LOADADDR(.text) + SIZEOF(.text)) {
+		*(INIT_TEXT_START)
+		*(INIT_TEXT)
+                _init_execrh = INIT_EXECRH;
+                _init_memset = INIT_MEMSET;
+                _init_fmemset = INIT_FMEMSET;
+                _init_memcmp = INIT_MEMCMP;
+                _init_fmemcmp = INIT_FMEMCMP;
+                _init_memcpy = INIT_MEMCPY;
+                _init_fmemcpy = INIT_FMEMCPY;
+                _init_strcpy = INIT_STRCPY;
+                _init_strlen = INIT_STRLEN;
+                _init_strchr = INIT_STRCHR;
+                _UMB_get_largest = UMB_GET_LARGEST;
+		_init_call_intr = INIT_CALL_INTR;
+		_read = READ;
+		_init_DosOpen = INIT_DOSOPEN;
+		_close = CLOSE;
+		_dup2 = DUP2;
+		_lseek = LSEEK;
+		_allocmem = ALLOCMEM;
+		_init_PSPSet = INIT_PSPSET;
+		_init_DosExec = INIT_DOSEXEC;
+		_init_setdrive = INIT_SETDRIVE;
+		_init_switchar = INIT_SWITCHAR;
+		_keycheck = KEYCHECK;
+		_set_DTA = SET_DTA;
+		_DetectXMSDriver = DETECTXMSDRIVER;
+		_init_call_XMScall = INIT_CALL_XMSCALL;
+		__EnableA20 = _ENABLEA20;
+		__DisableA20 = _DISABLEA20;
+		*(.text)
+		*(INIT_TEXT_END)
+		ASSERT(. <= 0x10000,
+		    "Error: too large for a small-model .exe file.");
+	}
+
+    /* Target init data sections.  */
+    .idata 0 : AT (LOADADDR(.itext) + SIZEOF(.itext)) {
+		*(ID_B)
+		*(.data)
+		*(.rodata) *(.rodata.*)
+		*(ID_E)
+	}
+    .ibss (NOLOAD) : AT (LOADADDR(.idata) + SIZEOF(.idata)) {
+		*(IB_B)
+		*(.bss)
+		*(IB_E)
+	}
+    .istack 0 (NOLOAD) : AT (LOADADDR(.ibss) + SIZEOF(.ibss)) {
+		*(_STACK)
+		. = 0x1000;
+	}
+    /DISCARD/ : { *(.*) }
+  }

--- a/kernel/kernel.ld
+++ b/kernel/kernel.ld
@@ -158,8 +158,6 @@ SECTIONS
 		_set_DTA = SET_DTA;
 		_DetectXMSDriver = DETECTXMSDRIVER;
 		_init_call_XMScall = INIT_CALL_XMSCALL;
-		__EnableA20 = _ENABLEA20;
-		__DisableA20 = _DISABLEA20;
 		*(.text)
 		*(INIT_TEXT_END)
 		ASSERT(. <= 0x10000,

--- a/kernel/ludivmul.inc
+++ b/kernel/ludivmul.inc
@@ -109,4 +109,30 @@
 	pop     si                 ;  variables
 	ret
 
-%endmacro   
+%endmacro
+
+%macro LSHLU 0
+	pop bx
+	pop ax
+	pop dx
+	pop cx
+	push bx
+	jcxz %%ret
+%%loop: shl ax, 1
+	rcl dx, 1
+	loop %%loop
+%%ret:	ret 6
+%endmacro
+
+%macro LSHRU 0
+	pop bx
+	pop ax
+	pop dx
+	pop cx
+	push bx
+	jcxz %%ret
+%%loop: shr dx, 1
+	rcr ax, 1
+	loop %%loop
+%%ret:	ret 6
+%endmacro

--- a/kernel/ludivmul.inc
+++ b/kernel/ludivmul.inc
@@ -51,6 +51,15 @@
 ; destroys:
 ;   flags
 ;
+%ifdef STDCALL
+	push bp
+	mov bp, sp
+	mov ax, [bp+6]
+	mov dx, [bp+8]
+	mov bx, [bp+10]
+	mov cx, [bp+12]
+	pop bp
+%endif
 
 	test    cx, cx             ; divisor > 2^32-1 ?
 	jnz     %%big_divisor      ; yes, divisor > 32^32-1
@@ -113,12 +122,10 @@
 
 %macro LSHLU 0
 	pop bx
-	pop ax
-	pop dx
-	pop cx
+	popargs {dx,ax},cx
 	push bx
 	jcxz %%ret
-%%loop: shl ax, 1
+%%loop:	shl ax, 1
 	rcl dx, 1
 	loop %%loop
 %%ret:	ret 6
@@ -126,12 +133,10 @@
 
 %macro LSHRU 0
 	pop bx
-	pop ax
-	pop dx
-	pop cx
+	popargs {dx,ax},cx
 	push bx
 	jcxz %%ret
-%%loop: shr dx, 1
+%%loop:	shr dx, 1
 	rcr ax, 1
 	loop %%loop
 %%ret:	ret 6

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -271,10 +271,10 @@ STATIC void setup_int_vectors(void)
   for (plvec = intvec_table; plvec < intvec_table + 5; plvec++)
     plvec->isv = getvec(plvec->intno);
   for (i = 0x23; i <= 0x3f; i++)
-    setvec(i, empty_handler);
+    setvec(i, DOSDATA(empty_handler));
   HaltCpuWhileIdle = 0;
   for (pvec = vectors; pvec < vectors + (sizeof vectors/sizeof *pvec); pvec++)
-    setvec(pvec->intno, (intvec)MK_FP(FP_SEG(empty_handler), pvec->handleroff));
+    setvec(pvec->intno, (intvec)MK_FP(FP_SEG(DOSDATA(empty_handler)), pvec->handleroff));
   pokeb(0, 0x30 * 4, 0xea);
   pokel(0, 0x30 * 4 + 1, (ULONG)cpm_entry);
 

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -158,7 +158,7 @@ initclk.obj: initclk.c  $(INITHEADERS) $(TARGET).lnk
 
 #the string functions for INIT_TEXT
 iasmsupt.obj: asmsupt.asm $(TARGET).lnk
-	$(NASM) -D$(COMPILER) -D_INIT $(NASMFLAGS) -f obj -o iasmsupt.obj asmsupt.asm
+	$(NASM) -D$(COMPILER) -D_INIT -f obj $(NASMFLAGS) -o iasmsupt.obj asmsupt.asm
 
 #the printf for INIT_TEXT - yet another special case, this file includes prf.c
 iprf.obj: iprf.c prf.c $(HDR)portab.h $(TARGET).lnk

--- a/kernel/makefile
+++ b/kernel/makefile
@@ -43,7 +43,7 @@ kernel.exe:	$(TARGET).lnk $(OBJS) $(LIBS)
 		$(LINK) @$(TARGET).lnk;
 
 ../bin/country.sys: country.asm
-		$(NASM) -o $*.sys country.asm
+		$(NASM) -o ../bin/country.sys country.asm
 
 clobber:        clean
 		-$(RM) kernel.exe kernel.sys status.me

--- a/kernel/memmgr.c
+++ b/kernel/memmgr.c
@@ -316,7 +316,7 @@ COUNT DosMemFree(UWORD para)
  */
 COUNT DosMemChange(UWORD para, UWORD size, UWORD * maxSize)
 {
-  REG mcb FAR *p, FAR * q;
+  REG mcb FAR *p; mcb FAR * q;
 
   /* Initialize                                                   */
   p = para2far(para - 1);       /* pointer to MCB */

--- a/kernel/nls.c
+++ b/kernel/nls.c
@@ -98,6 +98,9 @@ struct nlsInfoBlock ASM nlsInfo = {
  ***** MUX calling functions ****************************************
  ********************************************************************/
 
+#ifdef __GNUC__
+#define call_nls(a,b,c,d,e,f) call_nls(f,e,d,c,b,a)
+#endif
 extern long ASMPASCAL call_nls(UWORD, VOID FAR *, UWORD, UWORD, UWORD, UWORD);
 /*== DS:SI _always_ points to global NLS info structure <-> no
  * subfct can use these registers for anything different. ==ska*/

--- a/kernel/nls.c
+++ b/kernel/nls.c
@@ -66,8 +66,13 @@ struct nlsInfoBlock ASM nlsInfo = {
 #ifdef NLS_REORDER_POINTERS
       | NLS_CODE_REORDER_POINTERS
 #endif
+#ifdef __GNUC__
+      , {.seg=DosDataSeg, .off=&nlsPackageHardcoded} /* hardcoded first package */
+      , {.seg=DosDataSeg, .off=&nlsPackageHardcoded} /* first item in chain */
+#else
       , &nlsPackageHardcoded    /* hardcoded first package */
       , &nlsPackageHardcoded    /* first item in chain */
+#endif
 };
 
         /* getTableX return the pointer to the X'th table; X==subfct */

--- a/kernel/nls.c
+++ b/kernel/nls.c
@@ -509,7 +509,7 @@ VOID DosUpMem(VOID FAR * str, unsigned len)
  * the HiByte of the first argument must remain unchanged.
  *	See NLSSUPT.ASM -- 2000/03/30 ska
  */
-unsigned char ASMCFUNC DosUpChar(unsigned char ch)
+unsigned char ASMCFUNC DosUpChar(unsigned char ch, ...)
  /* upcase a single character */
 {
   log(("NLS: DosUpChar(): in ch=%u (%c)\n", ch, ch > 32 ? ch : ' '));
@@ -667,7 +667,7 @@ VOID FAR *DosGetDBCS(void)
 	Return value: AL register to be returned
 		if AL == 0, Carry must be cleared, otherwise set
 */
-UWORD ASMCFUNC syscall_MUX14(DIRECT_IREGS)
+UWORD ASMCFUNC syscall_MUX14(DIRECT_IREGS, ...)
 {
   struct nlsPackage FAR *nls;   /* addressed NLS package */
 

--- a/kernel/nls_hc.asm
+++ b/kernel/nls_hc.asm
@@ -14,15 +14,15 @@ _nlsPackageHardcoded:
 	DB  000h, 000h, 000h, 000h, 001h, 000h, 0b5h, 001h
 	DB  00fh, 000h, 059h, 000h, 04eh, 000h, 006h, 000h
 	DB  002h
-	DW ?table2, SEG ?table2
+	DW ?table2, DGROUP
 	DB  004h
-	DW ?table4, SEG ?table4
+	DW ?table4, DGROUP
 	DB  005h
-	DW ?table5, SEG ?table5
+	DW ?table5, DGROUP
 	DB  006h
-	DW ?table6, SEG ?table6
+	DW ?table6, DGROUP
 	DB  007h
-	DW ?table7, SEG ?table7
+	DW ?table7, DGROUP
 	GLOBAL _nlsCountryInfoHardcoded
 _nlsCountryInfoHardcoded:
 	DB  001h
@@ -32,8 +32,8 @@ _nlsCntryInfoHardcoded:
 	DB  01ch, 000h, 001h, 000h, 0b5h, 001h, 000h, 000h
 	DB  024h, 000h, 000h, 000h, 000h, 02ch, 000h, 02eh
 	DB  000h, 02dh, 000h, 03ah, 000h, 000h, 002h, 000h
-extern _CharMapSrvc:wrt DGROUP
-        DW  _CharMapSrvc, SEG _CharMapSrvc
+extern _CharMapSrvc
+        DW  _CharMapSrvc, DGROUP
         DB  02ch, 000h
 	GLOBAL _hcTablesStart
 _hcTablesStart:

--- a/kernel/prf.c
+++ b/kernel/prf.c
@@ -29,7 +29,11 @@
 #include "portab.h"
 
 #ifdef FORSYS
+#ifdef __GNUC__
+#include <unistd.h>
+#else
 #include <io.h>
+#endif
 #include <stdarg.h>
 #endif
 
@@ -105,6 +109,8 @@ void put_console(int c)
   __int__(0x29);
 #elif defined(__WATCOMC__)
   int29(c);
+#elif defined(__GNUC__)
+  asm volatile("int $0x29" : : "a"(c) : "bx");
 #elif defined(I86)
   __asm
   {
@@ -227,7 +233,8 @@ int VA_CDECL sprintf(char * buff, CONST char * fmt, ...)
 STATIC void do_printf(CONST BYTE * fmt, va_list arg)
 {
   int base;
-  BYTE s[11], FAR * p;
+  BYTE s[11];
+  BYTE FAR * p;
   int size;
   unsigned char flags;
 

--- a/kernel/procsupt.asm
+++ b/kernel/procsupt.asm
@@ -31,10 +31,10 @@
 
 		%include "segs.inc"
 
-                extern  _user_r:wrt DGROUP
+                extern  _user_r
 
-                extern  _break_flg:wrt DGROUP   ; break detected flag
-                extern  _int21_handler:wrt DGROUP ; far call system services
+                extern  _break_flg     ; break detected flag
+                extern  _int21_handler ; far call system services
 
                 %include "stacks.inc"
 
@@ -71,7 +71,7 @@ _exec_user:
 ;
                 POP$ALL
                 extern _ExecUserDisableA20
-                jmp far _ExecUserDisableA20
+                jmp DGROUP:_ExecUserDisableA20
 do_iret:
                 extern _int21_iret
                 jmp _int21_iret
@@ -263,7 +263,7 @@ _spawn_int23:
 
 ??int23_respawn:
 				pop bp					;; Restore the original register
-                jmp 	far _int21_handler
+                jmp 	DGROUP:_int21_handler
 
 ;
 ; interrupt enable and disable routines

--- a/kernel/proto.h
+++ b/kernel/proto.h
@@ -260,7 +260,7 @@ BYTE DosYesNo(UWORD ch);
 #ifndef DosUpMem
 VOID DosUpMem(VOID FAR * str, unsigned len);
 #endif
-unsigned char ASMCFUNC DosUpChar(unsigned char ch);
+unsigned char ASMCFUNC DosUpChar(unsigned char ch, ...);
 VOID DosUpString(char FAR * str);
 VOID DosUpFMem(VOID FAR * str, unsigned len);
 unsigned char DosUpFChar(unsigned char ch);
@@ -276,7 +276,7 @@ COUNT DosSetCountry(UWORD cntry);
 COUNT DosGetCodepage(UWORD * actCP, UWORD * sysCP);
 COUNT DosSetCodepage(UWORD actCP, UWORD sysCP);
 VOID FAR *DosGetDBCS(void);
-UWORD ASMCFUNC syscall_MUX14(DIRECT_IREGS);
+UWORD ASMCFUNC syscall_MUX14(DIRECT_IREGS, ...);
 
 /* prf.c */
 #ifdef DEBUG
@@ -383,7 +383,7 @@ UWORD get_machine_name(BYTE FAR * netname);
 VOID set_machine_name(BYTE FAR * netname, UWORD name_num);
 
 /* procsupt.asm */
-VOID ASMCFUNC exec_user(iregs FAR * irp, int disable_a20);
+VOID ASMCFUNC exec_user(iregs FAR * irp, int disable_a20, ...);
 
 /* new by TE */
 

--- a/kernel/segs.inc
+++ b/kernel/segs.inc
@@ -43,57 +43,81 @@ CPU XCPU
 %define WATCOM
 %endif
 
+%ifidn __OUTPUT_FORMAT__, obj
 group   PGROUP          PSP
 group   LGROUP          _IRQTEXT _LOWTEXT _IO_TEXT _IO_FIXED_DATA _TEXT
 group   DGROUP          _FIXED_DATA _BSS _DATA _DATAEND CONST CONST2 DCONST DYN_DATA
 %ifdef WATCOM
 group   TGROUP          HMA_TEXT_START HMA_TEXT HMA_TEXT_END INIT_TEXT_START INIT_TEXT INIT_TEXT_END
+%define IGROUP          TGROUP
 group   I_GROUP         ID_B I_DATA ICONST ICONST2 ID_E IB_B I_BSS IB_E
 %else
 group   TGROUP          HMA_TEXT_START HMA_TEXT HMA_TEXT_END
 group   IGROUP          INIT_TEXT_START INIT_TEXT INIT_TEXT_END
 group   I_GROUP         ID_B ID ID_E IC IDATA IB_B IB IB_E
 %endif
+%define class(x) class=x
+%define nobits
+%define exec
+%define INITSIZE init_end wrt INIT_TEXT
+%define INITTEXTSIZE __INIT_DATA_START wrt INIT_TEXT
 
-segment PSP             class=PSP
-segment	_IRQTEXT	class=LCODE
-segment	_LOWTEXT	class=LCODE
-segment	_IO_TEXT	class=LCODE
-segment	_IO_FIXED_DATA	class=LCODE align=2
-segment	_TEXT		class=LCODE
-segment	_FIXED_DATA	class=FDATA align=16
-segment	_BSS		class=BSS align=2
-segment _DATA           class=DATA align=2
-segment _DATAEND        class=DATA align=1
+%else ; using ELF
+
+BITS 16
+; groups are defined in the linker script kernel.ld
+extern PGROUP
+extern DGROUP
+extern LGROUP
+extern TGROUP
+extern IGROUP
+extern I_GROUP
+%define class(x)
+%define stack
+extern INITSIZE
+%define INITTEXTSIZE __InitTextEnd
+
+%endif
+
+segment PSP             class(PSP)
+segment	_IRQTEXT	class(LCODE) exec
+segment	_LOWTEXT	class(LCODE) exec
+segment	_IO_TEXT	class(LCODE) exec
+segment	_IO_FIXED_DATA	class(LCODE) align=2
+segment	_TEXT		class(LCODE) exec
+segment	_FIXED_DATA	class(FDATA) align=16
+segment	_BSS		class(BSS) align=2
+segment _DATA           class(DATA) align=2
+segment _DATAEND        class(DATA) align=1
 ;for WATCOM
-segment CONST		class=DATA align=2
-segment CONST2		class=DATA align=2
+segment CONST		class(DATA) align=2
+segment CONST2		class(DATA) align=2
 ;for MSC
-segment	DCONST      	class=DCONST   align=2     
-segment	DYN_DATA        class=DYN_DATA
-segment	HMA_TEXT_START	class=CODE align=16
-segment	HMA_TEXT	class=CODE
-segment HMA_TEXT_END	class=CODE
-segment INIT_TEXT_START class=CODE align=16
-segment	INIT_TEXT	class=CODE
-segment	INIT_TEXT_END   class=CODE
+segment	DCONST      	class(DCONST) align=2
+segment	DYN_DATA        class(DYN_DATA)
+segment	HMA_TEXT_START	class(CODE) align=16
+segment	HMA_TEXT	class(CODE) exec
+segment HMA_TEXT_END	class(CODE) align=16
+segment INIT_TEXT_START class(CODE) align=16
+segment	INIT_TEXT	class(CODE) exec
+segment	INIT_TEXT_END   class(CODE) align=16
 
 %ifdef WATCOM
-segment ID_B            class=FAR_DATA align=16
-segment I_DATA          class=FAR_DATA align=2
-segment ICONST          class=FAR_DATA align=2
-segment ICONST2         class=FAR_DATA align=2
-segment ID_E            class=FAR_DATA align=2
-segment IB_B            class=FAR_DATA align=2
-segment I_BSS           class=FAR_DATA align=2
-segment IB_E            class=FAR_DATA align=2
+segment ID_B            class(FAR_DATA) align=16
+segment I_DATA          class(FAR_DATA) align=2
+segment ICONST          class(FAR_DATA) align=2
+segment ICONST2         class(FAR_DATA) align=2
+segment ID_E            class(FAR_DATA) align=2
+segment IB_B            class(FAR_DATA) align=2
+segment I_BSS           class(FAR_DATA) align=2
+segment IB_E            class(FAR_DATA) align=2
 %else
-segment ID_B            class=ID   align=16
-segment ID              class=ID   align=2
-segment IDATA           class=ID   align=2
-segment ID_E            class=ID   align=2
-segment	IC      	class=IC   align=2
-segment	IB_B      	class=IB   align=2
-segment	IB      	class=IB   align=2     
-segment	IB_E      	class=IB   align=2
+segment ID_B            class(ID)  align=16
+segment ID              class(ID)  align=2
+segment IDATA           class(ID)  align=2
+segment ID_E            class(ID)  align=2
+segment	IC      	class(IC)  align=2
+segment	IB_B      	class(IB)  align=2 nobits
+segment	IB      	class(IB)  align=2 nobits
+segment	IB_E      	class(IB)  align=2 nobits
 %endif

--- a/kernel/serial.asm
+++ b/kernel/serial.asm
@@ -50,7 +50,7 @@ ComTable        db      0Ah
 
 segment	_IO_TEXT
 
-                extern   CommonNdRdExit:wrt LGROUP
+                extern   CommonNdRdExit
 
 ComRead:
                 jcxz    ComRd3

--- a/kernel/sysclk.c
+++ b/kernel/sysclk.c
@@ -58,7 +58,7 @@ STATIC void DayToBcd(BYTE * x, unsigned mon, unsigned day, unsigned yr)
   x[2] = ByteToBcd(yr % 100);
 }
 
-WORD ASMCFUNC FAR clk_driver(rqptr rp)
+WORD ASMCFUNC FAR clk_driver(rqptr rp, ...)
 {
   BYTE bcd_days[4], bcd_minutes, bcd_hours, bcd_seconds;
 

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -509,7 +509,7 @@ COUNT DosComLoader(BYTE FAR * namep, exec_blk * exp, COUNT mode, COUNT fd)
 
 VOID return_user(void)
 {
-  psp FAR *p, FAR * q;
+  psp FAR *p; psp FAR * q;
   REG COUNT i;
   iregs FAR *irp;
 /*  long j;*/

--- a/kernel/task.c
+++ b/kernel/task.c
@@ -800,7 +800,7 @@ COUNT DosExec(COUNT mode, exec_blk FAR * ep, BYTE FAR * lp)
 #include "config.h" /* config structure definition */
 
 /* start process 0 (the shell) */
-VOID ASMCFUNC P_0(struct config FAR *Config)
+VOID ASMCFUNC P_0(struct config FAR *Config, ...)
 {
   BYTE *tailp, *endp;
   exec_blk exb;

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -3,7 +3,7 @@
 #
 
 CC=ia16-elf-gcc -c
-CL=echo ia16-elf-gcc
+CL=ia16-elf-gcc
 INCLUDEPATH=.
 
 !if $(XCPU) != 186
@@ -26,6 +26,7 @@ TARGET=KGC
 # heavy stuff - building  
 #
 # -mcmodel=small small memory model (small code/small data)
+# -Os           -> favor code size over execution time in optimizations
 # -fleading-underscore underscores leading field for DOS compiler compat
 # -fno-common    no "common" variables, just BSS for uninitialized data
 # -fpack-struct pack structure members
@@ -35,17 +36,17 @@ TARGET=KGC
 # -w            disable warnings for now
 # -Werror       treat all warnings as errors
 
-ALLCFLAGS=-I../hdr $(TARGETOPT) $(ALLCFLAGS) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -w -Werror
+ALLCFLAGS=-I../hdr $(TARGETOPT) $(ALLCFLAGS) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -w -Werror -Os
 INITCFLAGS=$(ALLCFLAGS) -o $@
 CFLAGS=$(ALLCFLAGS) -o $@
 NASMFLAGS=$(NASMFLAGS) -f elf -o $@
 
 DIRSEP=/
 RM=rm -f
-CP=echo cp
+CP=cp
 ECHOTO=echo>>
 INITPATCH=@echo > /dev/null
 CLDEF=1
 CLT=gcc -DDOSC_TIME_H -I../hdr -o $@
 CLC=$(CLT)
-XLINK=echo $(XLINK) debug all op symfile format dos option map,statics,verbose F { $(OBJS) } L ../lib/device.lib N kernel.exe $#
+XLINK=$(CL) -Tkernel.ld -Wl,-Map,kernel.map -o kernel.exe $(OBJS) -Wl,--whole-archive ../drivers/device.lib -Wl,--no-whole-archive $#

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -12,7 +12,7 @@ TARGETOPT=-march=i8086
 !endif
 !endif
 
-LIBUTIL=wlib -q
+LIBUTIL=ar crs
 LIBPLUS=
 LIBTERM=
 

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -2,15 +2,34 @@
 # GCC.MAK - kernel compiler options for ia16-elf-gcc
 #
 
+#**********************************************************************
+#* TARGET    : we create a %TARGET%.sys file
+#* TARGETOPT : options, handled down to the compiler
+#**********************************************************************
+
+TARGET=KGC$(XCPU)$(XFAT)
+TARGETOPT=-march=i8086
+
+ifeq ($(XCPU),186)
+TARGETOPT=march=i80186
+ALLCFLAGS+=-DI186
+endif
+ifeq ($(XCPU),386)
+TARGETOPT=-march=i80286
+ALLCFLAGS+=-DI386
+endif
+
+ifeq ($(XFAT),32)
+ALLCFLAGS+=-DWITHFAT32
+NASMFLAGS+=-DWITHFAT32
+endif
+
+NASM=$(XNASM)
+NASMFLAGS+=-i../hdr/ -DXCPU=$(XCPU) -felf -o $@
+
 CC=ia16-elf-gcc -c
 CL=ia16-elf-gcc
 INCLUDEPATH=.
-
-!if $(XCPU) != 186
-!if $(XCPU) != 386
-TARGETOPT=-march=i8086
-!endif
-!endif
 
 LIBUTIL=ar crs
 LIBPLUS=
@@ -19,8 +38,6 @@ LIBTERM=
 TINY=-mcmodel=tiny
 CFLAGST=-Os -fpack-struct -fcall-used-es -w -o $@
 CFLAGSC=
-
-TARGET=KGC
 
 #
 # heavy stuff - building  
@@ -36,17 +53,29 @@ TARGET=KGC
 # -w            disable warnings for now
 # -Werror       treat all warnings as errors
 
-ALLCFLAGS=-I../hdr $(TARGETOPT) $(ALLCFLAGS) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -w -Werror -Os
+ALLCFLAGS+=-I../hdr $(TARGETOPT) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -w -Werror -Os
 INITCFLAGS=$(ALLCFLAGS) -o $@
 CFLAGS=$(ALLCFLAGS) -o $@
-NASMFLAGS=$(NASMFLAGS) -f elf -o $@
 
 DIRSEP=/
 RM=rm -f
 CP=cp
 ECHOTO=echo>>
+ifeq ($(LOADSEG)0, 0)
+LOADSEG=0x60
+endif
+
 INITPATCH=objcopy --redefine-sym ___umodsi3=_init_umodsi3 --redefine-sym ___udivsi3=_init_udivsi3 --redefine-sym ___ashlsi3=_init_ashlsi3 --redefine-sym ___lshrsi3=_init_lshrsi3
 CLDEF=1
 CLT=gcc -DDOSC_TIME_H -I../hdr -o $@
 CLC=$(CLT)
-XLINK=$(CL) -Tkernel.ld -Wl,-Map,kernel.map -o kernel.exe $(OBJS) -Wl,--whole-archive ../drivers/device.lib -Wl,--no-whole-archive $#
+LINK=$(XLINK) -Tkernel.ld -Wl,-Map,kernel.map -o kernel.exe $(OBJS) -Wl,--whole-archive ../drivers/device.lib -Wl,--no-whole-archive \#
+
+.SUFFIXES: .obj .asm
+
+#               *Implicit Rules*
+.asm.obj :
+	$(NASM) -D$(COMPILER) $(NASMFLAGS) $*.asm
+
+.c.obj :
+	$(CC) $(CFLAGS) $*.c

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -45,7 +45,7 @@ DIRSEP=/
 RM=rm -f
 CP=cp
 ECHOTO=echo>>
-INITPATCH=@echo > /dev/null
+INITPATCH=objcopy --redefine-sym ___umodsi3=_init_umodsi3 --redefine-sym ___udivsi3=_init_udivsi3 --redefine-sym ___ashlsi3=_init_ashlsi3 --redefine-sym ___lshrsi3=_init_lshrsi3
 CLDEF=1
 CLT=gcc -DDOSC_TIME_H -I../hdr -o $@
 CLC=$(CLT)

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -36,7 +36,7 @@ LIBPLUS=
 LIBTERM=
 
 TINY=-mcmodel=tiny
-CFLAGST=-Os -fpack-struct -fcall-used-es -w -o $@
+CFLAGST=-Os -fno-strict-aliasing -fpack-struct -fcall-used-es -Wno-pointer-to-int-cast -Wno-pragmas -Wno-array-bounds -Werror -o $@
 CFLAGSC=
 
 #
@@ -44,16 +44,18 @@ CFLAGSC=
 #
 # -mcmodel=small small memory model (small code/small data)
 # -Os           -> favor code size over execution time in optimizations
+# -fno-strict-aliasing don't assume strict aliasing rules
 # -fleading-underscore underscores leading field for DOS compiler compat
 # -fno-common    no "common" variables, just BSS for uninitialized data
 # -fpack-struct pack structure members
 # -ffreestanding don't assume any headers
 # -fcall-used-es es clobbered in function calls
 # -mrtd         use stdcall calling convention
-# -w            disable warnings for now
+# -Wno-pointer-to-int-cast  do not warn about FP_OFF
+# -Wno-pragmas  do not warn about #pragma pack
 # -Werror       treat all warnings as errors
 
-ALLCFLAGS+=-I../hdr $(TARGETOPT) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -w -Werror -Os
+ALLCFLAGS+=-I../hdr $(TARGETOPT) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -Wno-pointer-to-int-cast -Wno-pragmas -Werror -Os -fno-strict-aliasing
 INITCFLAGS=$(ALLCFLAGS) -o $@
 CFLAGS=$(ALLCFLAGS) -o $@
 

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -17,7 +17,7 @@ LIBPLUS=
 LIBTERM=
 
 TINY=-mcmodel=tiny
-CFLAGST=-w -o $@
+CFLAGST=-Os -fpack-struct -fcall-used-es -w -o $@
 CFLAGSC=
 
 TARGET=KGC

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -1,0 +1,50 @@
+#
+# GCC.MAK - kernel compiler options for ia16-elf-gcc
+#
+
+CC=ia16-elf-gcc -c
+CL=echo ia16-elf-gcc
+INCLUDEPATH=.
+
+!if $(XCPU) != 186
+!if $(XCPU) != 386
+TARGETOPT=-march=i8086
+!endif
+!endif
+
+LIBUTIL=wlib -q
+LIBPLUS=
+LIBTERM=
+
+TINY=-mcmodel=tiny
+CFLAGST=-w -o $@
+CFLAGSC=
+
+TARGET=KGC
+
+#
+# heavy stuff - building  
+#
+# -mcmodel=small small memory model (small code/small data)
+# -fleading-underscore underscores leading field for DOS compiler compat
+# -fno-common    no "common" variables, just BSS for uninitialized data
+# -fpack-struct pack structure members
+# -ffreestanding don't assume any headers
+# -fcall-used-es es clobbered in function calls
+# -mrtd         use stdcall calling convention
+# -w            disable warnings for now
+# -Werror       treat all warnings as errors
+
+ALLCFLAGS=-I../hdr $(TARGETOPT) $(ALLCFLAGS) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -w -Werror
+INITCFLAGS=$(ALLCFLAGS) -o $@
+CFLAGS=$(ALLCFLAGS) -o $@
+
+DIRSEP=/
+RM=rm -f
+CP=echo cp
+ECHOTO=echo>>
+INITPATCH=@echo > /dev/null
+CLDEF=1
+CLT=gcc -DDOSC_TIME_H -I../hdr -o $@
+CLC=$(CLT)
+XLINK=echo $(XLINK) debug all op symfile format dos option map,statics,verbose F { $(OBJS) } L ../lib/device.lib N kernel.exe $#

--- a/mkfiles/gcc.mak
+++ b/mkfiles/gcc.mak
@@ -38,6 +38,7 @@ TARGET=KGC
 ALLCFLAGS=-I../hdr $(TARGETOPT) $(ALLCFLAGS) -mcmodel=small -fleading-underscore -fno-common -fpack-struct -ffreestanding -fcall-used-es -mrtd -w -Werror
 INITCFLAGS=$(ALLCFLAGS) -o $@
 CFLAGS=$(ALLCFLAGS) -o $@
+NASMFLAGS=$(NASMFLAGS) -f elf -o $@
 
 DIRSEP=/
 RM=rm -f

--- a/mkfiles/generic.mak
+++ b/mkfiles/generic.mak
@@ -47,7 +47,7 @@ CLC=$(CL) $(CFLAGSC) -I$(INCLUDEPATH)
 TARGET=$(TARGET)$(XCPU)$(XFAT)
 
 .asm.obj :
-	$(NASM) -D$(COMPILER) $(NASMFLAGS) -f obj $*.asm
+	$(NASM) -D$(COMPILER) -f obj $(NASMFLAGS) $*.asm
 
 #               *Implicit Rules*
 .c.obj :

--- a/sys/fdkrncfg.c
+++ b/sys/fdkrncfg.c
@@ -19,7 +19,9 @@ char KERNEL[] = "KERNEL.SYS";
 
 #include <stdlib.h>
 #include <string.h>
+#ifndef __GNUC__
 #include <fcntl.h>
+#endif
 
 #include "portab.h"
 /* These definitions deliberately put here instead of
@@ -29,7 +31,7 @@ char KERNEL[] = "KERNEL.SYS";
 extern int VA_CDECL printf(CONST char * fmt, ...);
 extern int VA_CDECL sprintf(char * buff, CONST char * fmt, ...);
 
-#ifdef __WATCOMC__
+#if defined(__WATCOMC__)
 unsigned _dos_close(int handle);
 #define close _dos_close
 #define SEEK_SET 0
@@ -44,6 +46,11 @@ unsigned long lseek(int fildes, unsigned long offset, int whence);
       parm [bx] [dx cx] [ax] \
       value [dx ax];
 
+#elif defined(__GNUC__)
+#include <unistd.h>
+#include <fcntl.h>
+#define memicmp strncasecmp
+#define O_BINARY 0
 #else
 #include <io.h>
 #ifndef SEEK_SET

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -1128,7 +1128,7 @@ int generic_block_ioctl(unsigned drive, unsigned cx, unsigned char *par);
 
 #ifndef __TURBOC__
 
-int2526readwrite(int DosDrive, void *diskReadPacket, unsigned intno)
+int int2526readwrite(int DosDrive, void *diskReadPacket, unsigned intno)
 {
   union REGS regs;
 

--- a/sys/sys.c
+++ b/sys/sys.c
@@ -117,6 +117,52 @@ struct SREGS {
 struct _diskfree_t {
   unsigned short avail_clusters, sectors_per_cluster, bytes_per_sector;
 };
+
+int int86(int ivec, union REGS *in, union REGS *out)
+{
+}
+
+int intdos(union REGS *in, union REGS *out)
+{
+}
+
+int intdosx(union REGS *in, union REGS *out, struct SREGS *s)
+{
+}
+
+unsigned _dos_allocmem(unsigned size, unsigned *seg)
+{
+}
+
+unsigned _dos_freemem(unsigned seg)
+{
+}
+
+unsigned int _dos_getdiskfree(unsigned int drive,
+                              struct diskfree_t *diskspace)
+{
+}
+
+long filelength(int fhandle)
+{
+}
+
+struct find_t {
+  char reserved[21];
+  unsigned char attrib;
+  unsigned short wr_time;
+  unsigned short wr_date;
+  unsigned long size;
+  char filename[13];
+};
+#define _A_NORMAL 0x00
+#define _A_HIDDEN 0x02
+#define _A_SYSTEM 0x04
+
+int _dos_findfirst(const char *file_name, unsigned int attr,
+                   struct find_t *find_tbuf)
+{
+}
 #else
 #include <io.h>
 #endif
@@ -194,7 +240,9 @@ int write(int fd, const void *buf, unsigned count)
 }
 
 #define close _dos_close
+#endif
 
+#if defined(__WATCOMC__) || defined(__GNUC__)
 int stat(const char *file_name, struct stat *statbuf)
 {
   struct find_t find_tbuf;
@@ -204,7 +252,9 @@ int stat(const char *file_name, struct stat *statbuf)
   /* statbuf->st_attr = (ULONG)find_tbuf.attrib; */
   return ret;
 }
+#endif
 
+#ifdef __WATCOMC__
 /* WATCOM's getenv is case-insensitive which wastes a lot of space
    for our purposes. So here's a simple case-sensitive one */
 char *getenv(const char *name)

--- a/sys/talloc.c
+++ b/sys/talloc.c
@@ -33,6 +33,12 @@ extern unsigned __brklvl;
 
 #ifdef __GNUC__
 #include <unistd.h>
+static inline int brk(void *addr)
+{
+  char *brklvl = sbrk(0);
+  int *res = sbrk((char *)addr - brklvl);
+  return (res == (void *)-1) ? -1 : 0;
+}
 #endif
 
 #define BUSY	    (sizeof(size_t)-1)	/* Bit set if memory block in use*/


### PR DESCRIPTION
This patchset allows to compile the kernel using ia16-elf-gcc from https://github.com/tkchia/gcc-ia16.

Most of the changes deal with the following issues:
1. The compiler and linker do not understand OMF, only ELF, which does not understand far segments. We can work around that by defining symbols for DGROUP and friends in the linker script kernel.ld.
2. The compiler does not understand the PASCAL calling convention. It does support STDCALL however where arguments are reversed. I added macros in nasm to deal with those.
3. CDECL functions need to be declared using variable arguments (...), otherwise they use STDCALL (`__attribute((cdecl))__` is not supported yet).
4. The compiler understands far pointers but not far variables. Hence far variables need be accessed via a macro that does the equivalent of MK_FP(DGROUP, &var).
5. No far functions either. I needed to write asm wrappers for the 5 far functions (init_call_p_0, _EnableA20, _DisableA20, blk_driver and clk_driver).
6. For sys: it compiles using newlib which does not support any DOS-specific library calls, so they had to be written inside sys.c.
7. Makefiles. To eliminate all dependencies on OpenWatcom, use GNU Make thoughout. Because !include is not compatible with include, this needs a "sed" in the build procedure.
8. The syntax `BYTE far *buffer, far *bufptr;` is not supported. Instead, split the two declarations into `BYTE far *buffer; BYTE far *bufptr;`.
9. Initializers with far pointers need adjusting, using explicit segment, offset in some cases.

It works and boots. Only tested in DOSEMU so far though.

The binary for 86+FAT32 is ~77k, vs OW ~69k uncompressed.