### PR TITLE
Updates for ia16-elf-gcc

### DIFF
--- a/docs/build.txt
+++ b/docs/build.txt
@@ -36,9 +36,11 @@ make clobber
 You can now also cross compile with T.K. Chia's fork of ia16-elf-gcc,
 which is available at https://github.com/tkchia/gcc-ia16, using
 make all COMPILER=gcc
-or by setting COMPILER=gcc in config.mak. For now ia16-elf-gcc needs
-to be compiled from source. Only releases 20171210 and later
-are supported.
+or by setting COMPILER=gcc in config.mak. If you are using Ubuntu
+Linux 16.04 LTS (Xenial Xerus), there are precompiled ia16-elf-gcc
+packages at https://launchpad.net/~tkchia/+archive/ubuntu/build-ia16/.
+Otherwise, for now ia16-elf-gcc needs to be compiled from source.
+Only releases 20171210 and later are supported.
 
 Notes:
 ======

--- a/kernel/ludivmul.inc
+++ b/kernel/ludivmul.inc
@@ -128,7 +128,7 @@
 %%loop:	shl ax, 1
 	rcl dx, 1
 	loop %%loop
-%%ret:	ret 6
+%%ret:	ret
 %endmacro
 
 %macro LSHRU 0
@@ -139,5 +139,5 @@
 %%loop:	shr dx, 1
 	rcr ax, 1
 	loop %%loop
-%%ret:	ret 6
+%%ret:	ret
 %endmacro


### PR DESCRIPTION
A documentation update from TK Chia, and a critical (for ia16-elf-gcc only!) bug fix for the 32-bit shift routines.