### PR TITLE
FCB: Rename return value lost

### DIFF
--- a/kernel/fcbfns.c
+++ b/kernel/fcbfns.c
@@ -526,7 +526,7 @@ UBYTE FcbRename(xfcb FAR * lpXfcb)
   else
   {
     dmatch Dmatch;
-    COUNT result;
+    COUNT rc;
 
     wAttr = (lpXfcb->xfcb_flag == 0xff ? lpXfcb->xfcb_attrib : D_ALL);
     dta = &Dmatch;
@@ -561,9 +561,9 @@ UBYTE FcbRename(xfcb FAR * lpXfcb)
       SecPathName[0] = 'A' + FcbDrive - 1;
       SecPathName[1] = ':';
       strcpy(&SecPathName[2], Dmatch.dm_name);
-      result = truename(SecPathName, PriPathName, 0);
+      rc = truename(SecPathName, PriPathName, 0);
 
-      if (result < SUCCESS || (result & IS_DEVICE))
+      if (rc < SUCCESS || (rc & IS_DEVICE))
       {
         result = FCB_ERROR;
         break;
@@ -571,8 +571,8 @@ UBYTE FcbRename(xfcb FAR * lpXfcb)
       /* now to build a dos name again                */
       LocalFcb.fcb_drive = FcbDrive;
       FcbNameInit(&LocalFcb, loc_szBuffer, &FcbDrive);
-      result = truename(loc_szBuffer, SecPathName, 0);
-      if (result < SUCCESS || (result & (IS_NETWORK|IS_DEVICE)) == IS_DEVICE
+      rc = truename(loc_szBuffer, SecPathName, 0);
+      if (rc < SUCCESS || (rc & (IS_NETWORK|IS_DEVICE)) == IS_DEVICE
         || DosRenameTrue(PriPathName, SecPathName, wAttr) != SUCCESS)
       {
         result = FCB_ERROR;


### PR DESCRIPTION
Two variables named 'result' were defined, at the outer level a
UBYTE to hold the function return value and the inner a COUNT to
hold returns from 'truename()'. The overall function return value
was always FCB_SUCCESS due to shadowing, however removing the
inner variable definition as a fix does not work due to sign
issues and intermixing of the variable uses, so rename the inner
variable.

Tested this patch using FDPP platform
1/ Simple rename of file with conditions for success (ok)
2/ Simple rename of file with conditions for failure - source missing (ok)
3/ Simple rename of file with conditions for failure - target exists (ok)

Fixes #16