### PR TITLE
Fix func 36h (Get free disk space) fails for some network drives

### DIFF
--- a/kernel/dosfns.c
+++ b/kernel/dosfns.c
@@ -759,6 +759,7 @@ UWORD DosGetFree(UBYTE drive, UWORD * navc, UWORD * bps, UWORD * nc)
   if (cdsp == NULL)
     return spc;
 
+  current_ldt = cdsp;
   if (cdsp->cdsFlags & CDSNETWDRV)
   {
     if (remote_getfree(cdsp, rg) != SUCCESS)


### PR DESCRIPTION
needed for:
- David Maxey's PHANTOM.EXE (Undocumented DOS 2nd edition)
- Novell CD-ROM extension NWCDEX (DR DOS 7.03)
